### PR TITLE
Use https at dx.doi.org

### DIFF
--- a/apalike-refs.bst
+++ b/apalike-refs.bst
@@ -368,7 +368,7 @@ FUNCTION {format.doi}
 {
   doi empty$
     { "" }
-    { "DOI: \href{http://dx.doi.org/" doi * "}{\ttfamily " * doi escape.url.characters * "}" * }
+    { "DOI: \href{https://dx.doi.org/" doi * "}{\ttfamily " * doi escape.url.characters * "}" * }
   if$
 }
 


### PR DESCRIPTION
The web is moving to https anyway and openlibrary already uses https.

By the way, thanks for this style!